### PR TITLE
Accept client identity in HandleAwsRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/otterize/iamlive
 
-go 1.21
+go 1.22.1
+
+toolchain go1.23.4
 
 require (
 	github.com/Khan/genqlient v0.6.0
@@ -9,6 +11,7 @@ require (
 	github.com/inconshreveable/go-vhost v1.0.0
 	github.com/kenshaw/baseconv v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=
+github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f/go.mod h1:9SNBrJbNRAl1isohKk/t1Px85HuxPFylfMmOMVtCg2Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/iamlivecore/mapperclient/generate.go
+++ b/iamlivecore/mapperclient/generate.go
@@ -1,4 +1,5 @@
 package mapperclient
 
-//go:generate wget https://raw.githubusercontent.com/otterize/network-mapper/shavit/aws-intents/src/mappergraphql/schema.graphql -O ./schema.graphql -q
-//go:generate go run github.com/Khan/genqlient@v0.5.0 ./genqlient.yaml
+// TODO: set to main before merge
+//go:generate wget https://raw.githubusercontent.com/otterize/network-mapper/shavit/reportAWSOperation2/src/mappergraphql/schema.graphql -O ./schema.graphql -q
+//go:generate go run github.com/Khan/genqlient@v0.7.0 ./genqlient.yaml

--- a/iamlivecore/mapperclient/generated.go
+++ b/iamlivecore/mapperclient/generated.go
@@ -6,12 +6,14 @@ import (
 	"context"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/otterize/nilable"
 )
 
 type AWSOperation struct {
-	Resource string   `json:"resource"`
-	Actions  []string `json:"actions"`
-	SrcIp    string   `json:"srcIp"`
+	Resource string                          `json:"resource"`
+	Actions  []string                        `json:"actions"`
+	SrcIp    nilable.Nilable[string]         `json:"srcIp"`
+	Client   nilable.Nilable[NamespacedName] `json:"client"`
 }
 
 // GetResource returns AWSOperation.Resource, and is useful for accessing the field via an interface.
@@ -21,7 +23,21 @@ func (v *AWSOperation) GetResource() string { return v.Resource }
 func (v *AWSOperation) GetActions() []string { return v.Actions }
 
 // GetSrcIp returns AWSOperation.SrcIp, and is useful for accessing the field via an interface.
-func (v *AWSOperation) GetSrcIp() string { return v.SrcIp }
+func (v *AWSOperation) GetSrcIp() nilable.Nilable[string] { return v.SrcIp }
+
+// GetClient returns AWSOperation.Client, and is useful for accessing the field via an interface.
+func (v *AWSOperation) GetClient() nilable.Nilable[NamespacedName] { return v.Client }
+
+type NamespacedName struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// GetName returns NamespacedName.Name, and is useful for accessing the field via an interface.
+func (v *NamespacedName) GetName() string { return v.Name }
+
+// GetNamespace returns NamespacedName.Namespace, and is useful for accessing the field via an interface.
+func (v *NamespacedName) GetNamespace() string { return v.Namespace }
 
 // __reportAWSOperationInput is used internally by genqlient
 type __reportAWSOperationInput struct {
@@ -39,32 +55,35 @@ type reportAWSOperationResponse struct {
 // GetReportAWSOperation returns reportAWSOperationResponse.ReportAWSOperation, and is useful for accessing the field via an interface.
 func (v *reportAWSOperationResponse) GetReportAWSOperation() bool { return v.ReportAWSOperation }
 
-func reportAWSOperation(
-	ctx context.Context,
-	client graphql.Client,
-	operation []AWSOperation,
-) (*reportAWSOperationResponse, error) {
-	req := &graphql.Request{
-		OpName: "reportAWSOperation",
-		Query: `
+// The query or mutation executed by reportAWSOperation.
+const reportAWSOperation_Operation = `
 mutation reportAWSOperation ($operation: [AWSOperation!]!) {
 	reportAWSOperation(operation: $operation)
 }
-`,
+`
+
+func reportAWSOperation(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	operation []AWSOperation,
+) (*reportAWSOperationResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "reportAWSOperation",
+		Query:  reportAWSOperation_Operation,
 		Variables: &__reportAWSOperationInput{
 			Operation: operation,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data reportAWSOperationResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ reportAWSOperationResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }

--- a/iamlivecore/mapperclient/genqlient.yaml
+++ b/iamlivecore/mapperclient/genqlient.yaml
@@ -3,3 +3,5 @@ schema:
 operations:
   - genqlient.graphql
 generated: generated.go
+optional: generic
+optional_generic_type: github.com/otterize/nilable.Nilable

--- a/iamlivecore/mapperclient/schema.graphql
+++ b/iamlivecore/mapperclient/schema.graphql
@@ -5,6 +5,8 @@ input Destination {
     destination: String!
     # If destination is a hostname, this _may_ be the IP it resolves to if it is known, but is not required.
     destinationIP: String
+    destinationPort: Int
+    TTL: Int
     lastSeen: Time!
 }
 
@@ -15,6 +17,10 @@ input RecordedDestinationsForSrc {
 }
 
 input CaptureResults {
+    results: [RecordedDestinationsForSrc!]!
+}
+
+input CaptureTCPResults {
     results: [RecordedDestinationsForSrc!]!
 }
 
@@ -33,10 +39,22 @@ type GroupVersionKind {
     kind: String!
 }
 
+type IdentityResolutionData {
+    host: String
+    podHostname: String
+    procfsHostname: String
+    port: Int
+    isService: Boolean
+    uptime: String
+    lastSeen: String
+    extraInfo: String
+}
+
 type OtterizeServiceIdentity {
     name: String!
     namespace: String!
     labels: [PodLabel!]
+    resolutionData: IdentityResolutionData
     """
     If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
     """
@@ -95,6 +113,7 @@ type Intent {
     client: OtterizeServiceIdentity!
     server: OtterizeServiceIdentity!
     type: IntentType
+    resolutionData: String
     kafkaTopics: [KafkaConfig!]
     httpResources: [HttpResource!]
     awsActions: [String!]
@@ -122,6 +141,7 @@ input IstioConnection {
     srcWorkload: String!
     srcWorkloadNamespace: String!
     dstWorkload: String!
+    dstServiceName: String!
     dstWorkloadNamespace: String!
     path: String!
     methods: [HttpMethod!]!
@@ -132,15 +152,29 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input NamespacedName {
+    name: String!
+    namespace: String!
+}
+
 input AWSOperation {
     resource: String!
     actions: [String!]!
-    srcIp: String!
+    srcIp: String
+    client: NamespacedName
 }
 
 input ServerFilter {
     name: String!
     namespace: String!
+}
+
+input AzureOperation {
+    scope: String!
+    actions: [String!]!
+    dataActions: [String!]!
+    clientName: String!
+    clientNamespace: String!
 }
 
 type Query {
@@ -174,8 +208,10 @@ type Query {
 type Mutation {
     resetCapture: Boolean!
     reportCaptureResults(results: CaptureResults!): Boolean!
+    reportTCPCaptureResults(results: CaptureTCPResults!): Boolean!
     reportSocketScanResults(results: SocketScanResults!): Boolean!
     reportKafkaMapperResults(results: KafkaMapperResults!): Boolean!
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!
     reportAWSOperation(operation: [AWSOperation!]!): Boolean!
+    reportAzureOperation(operation: [AzureOperation!]!): Boolean!
 }

--- a/iamlivecore/proxy.go
+++ b/iamlivecore/proxy.go
@@ -202,7 +202,7 @@ func createProxy(addr string, sslAddr string) {
 				dumpReq(req)
 			}
 			body, _ = ioutil.ReadAll(req.Body)
-			HandleAWSRequest(req, body, 200)
+			HandleAWSRequest(req, body, 200, nil)
 		} else {
 			return req, nil
 		}
@@ -295,6 +295,11 @@ type ServiceDefinitionMetadata struct {
 	UID                 string `json:"uid"`
 }
 
+type NamespacedName struct {
+	Name      string
+	Namespace string
+}
+
 func ReadServiceFiles() {
 	if *providerFlag == "aws" {
 		files, err := serviceFiles.ReadDir("service")
@@ -366,7 +371,7 @@ type ActionCandidate struct {
 	Service   string
 }
 
-func HandleAWSRequest(req *http.Request, body []byte, respCode int) {
+func HandleAWSRequest(req *http.Request, body []byte, respCode int, clientIdentity *NamespacedName) {
 	host := req.Host
 	uri := req.RequestURI
 
@@ -704,6 +709,10 @@ func HandleAWSRequest(req *http.Request, body []byte, respCode int) {
 		FinalHTTPStatusCode: respCode,
 		AccessKey:           accessKey,
 		SrcIP:               strings.Split(req.RemoteAddr, ":")[0],
+	}
+
+	if clientIdentity != nil {
+		entry.ClientIdentity = clientIdentity
 	}
 
 	printCallInfo(entry)


### PR DESCRIPTION
### Description

Send client identity if known, and ~use the mapperclient from network-mapper~ (still need to generate it to avoid a cyclic dependency)


### References

Builds on: https://github.com/otterize/network-mapper/pull/258

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
